### PR TITLE
bugfix for not always loading default options into cache adapter

### DIFF
--- a/DependencyInjection/PsPdfExtension.php
+++ b/DependencyInjection/PsPdfExtension.php
@@ -60,7 +60,7 @@ class PsPdfExtension extends Extension
     {
         foreach($options as $name)
         {
-            if(!empty($config[$name]))
+            if(null !== $config[$name])
             {
                 $container->setParameter(sprintf($format, $name), $config[$name]);
             }


### PR DESCRIPTION
The option check in setGenericConfig was on !empty while an empty option should not always mean to load default options, only a null value should.
