### PR TITLE
Allow up to sensio/framework-extra-bundle v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.0",
         "symfony/symfony": "~2.3|~3.0",
         "psliwa/php-pdf": "^1.1.5",
-        "sensio/framework-extra-bundle": ">=2.0 <4.0.0"
+        "sensio/framework-extra-bundle": "^2|^3|^4|^5"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4,<6.0.0"


### PR DESCRIPTION
I've forked this bundle to try and overcome the limit of the `sensio/framework-extra-bundle` constraint. Luckily that dependency is used only to have the `@Pdf` annotation available, and the BC between v3 and v4/5 in the Sensio bundle doesn't affect us.

Hence, this fix is more than enough.